### PR TITLE
Feature/add habits list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  SuggestExtensions: false

--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -6,3 +6,61 @@
   float: left;
   margin: 5px;
 }
+
+.tooltip > .tooltip-inner {
+  background-color: #ededed;
+  border-color: #ededed;
+  color: #292c7b;
+}
+
+.tooltip {
+  overflow: auto;
+}
+
+.timeline {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  list-style-type: none;
+  height: 100px;
+}
+
+.timeline-item {
+  transition: all 200ms ease-in;
+}
+
+.checkpoint {
+  border-top: 3px solid #e8425a;
+  display: flex;
+  justify-content: center;
+  padding: 0px 20px;
+  position: relative;
+  transition: all 200ms ease-in;
+  &:hover:before {
+    background-color: #292c7b;
+  }
+}
+
+.checkpoint:before {
+  background-color: #e8425a;
+  border-radius: 25px;
+  border: 1px solid #ededed;
+  content: '';
+  height: 25px;
+  position: absolute;
+  top: -15px;
+  transition: all 200ms ease-in;
+  width: 25px;
+}
+
+.timeline-item.complete .checkpoint {
+  border-top: 3px solid #292c7b;
+  &:hover:before {
+    background-color: #ededed;
+  }
+}
+.timeline-item.complete .checkpoint:before {
+  background-color: #292c7b;
+  border: none;
+  transition: all 200ms ease-in;
+}

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -4,21 +4,21 @@ class HabitsController < ApplicationController
 
   def index
     @habit = Habit.new
+    @habits = HabitsQuery.new(current_user.habits)
   end
 
   def create
     @habit = current_user.habits.create(habit_params)
     if @habit.valid?
-      flash[:success] = "Habit created successfully"
-      redirect_to @habit 
+      flash[:success] = 'Habit created successfully'
+      redirect_to @habit
     else
-      flash[:danger] = "Error habit not created"
-      render :index
+      flash[:danger] = 'Error habit not created'
+      redirect_to habits_path
     end
   end
 
-  def show
-  end
+  def show; end
 
   def set_habit
     @habit = Habit.find(params[:id])
@@ -26,9 +26,10 @@ class HabitsController < ApplicationController
 
   def end_date_param
     raise MissingAttributeError unless params[:habit][:habit_duration]
+
     params[:habit][:start_date].to_date + params[:habit][:habit_duration].to_i.days
-    rescue
-      flash[:info] = "Invalid form"
+  rescue StandardError
+    flash[:info] = 'Invalid form'
   end
 
   def habit_params

--- a/app/queries/habits_query.rb
+++ b/app/queries/habits_query.rb
@@ -1,0 +1,15 @@
+class HabitsQuery
+  attr_reader :habits
+
+  def initialize(habits)
+    @habits = habits
+  end
+
+  def active
+    @habits.where(status: false)
+  end
+
+  def archived
+    @habits.where(status: true)
+  end
+end

--- a/app/views/habits/_empty_list.html.haml
+++ b/app/views/habits/_empty_list.html.haml
@@ -1,0 +1,1 @@
+%h5="You don't have #{habits_status} habits yet."

--- a/app/views/habits/_habit.html.haml
+++ b/app/views/habits/_habit.html.haml
@@ -1,0 +1,10 @@
+.col-xs-12.col-sm-6
+  .card
+    .card-body
+      %h5.card-title= habit.name
+      %p.card-text
+        %strong Start date:
+        = habit.start_date
+      %p.m-0
+        %strong Checkpoints:
+      %div.d-flex.overflow-auto

--- a/app/views/habits/_tab.html.haml
+++ b/app/views/habits/_tab.html.haml
@@ -1,0 +1,5 @@
+%ul.nav.nav-pills.mb-3#pills-tab{ 'role': 'tablist'}
+  %li.nav-item{ 'role': 'presentation' }
+    %button.nav-link.active#pills-active-habits-tab{ 'data-bs-toggle': 'pill', 'data-bs-target': '#pills-active-habits', 'type': 'button', 'role': 'tab', 'aria-controls': 'pills-active-habits', 'aria-selected': 'true' } Active habits
+  %li.nav-item{ 'role': 'presentation' }
+    %button.nav-link#pills-archived-habits-tab{ 'data-bs-toggle': 'pill', 'data-bs-target': '#pills-archived-habits', 'type': 'button', 'role': 'tab', 'aria-controls': 'pills-archived-habits', 'aria-selected': 'false' } Archived habits

--- a/app/views/habits/_tab_content.html.haml
+++ b/app/views/habits/_tab_content.html.haml
@@ -1,0 +1,7 @@
+.tab-content#pills-tabContent
+  .tab-pane.fade.show.active#pills-active-habits{ 'role': 'tabpanel', 'aria-labelledby': 'pills-active-habits-tab' }
+    .row.g-3
+      = render(partial: 'habit', collection: habits.active) || render(partial: 'empty_list', locals: { habits_status: 'active' })
+  .tab-pane.fade#pills-archived-habits{ role: 'tabpanel', 'aria-labelledby': 'pills-archived-habits-tab' }
+    .row.g-3
+      = render(partial: 'habit', collection: habits.archived) || render(partial: 'empty_list', locals: { habits_status: 'completed' })

--- a/app/views/habits/_timeline.html.haml
+++ b/app/views/habits/_timeline.html.haml
@@ -1,0 +1,11 @@
+%ul.timeline.p-0.m-0#timeline
+  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
+    .checkpoint
+  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
+    .checkpoint
+  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
+    .checkpoint
+  %li.timeline-item{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses" }
+    .checkpoint
+  %li.timeline-item
+    .checkpoint{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses" }

--- a/app/views/habits/index.html.haml
+++ b/app/views/habits/index.html.haml
@@ -1,4 +1,7 @@
-%button.btn.btn-primary{ 'type': "button", 'data-bs-toggle': "modal", 'data-bs-target': "#staticBackdrop"} Add New Habit
+.d-flex.justify-content-end.mb-3
+  %button.btn.btn-primary.ml-auto{ 'type': 'button', 'data-bs-toggle': 'modal', 'data-bs-target': '#staticBackdrop'} Add New Habit
+= render 'tab'
+= render 'tab_content', habits: @habits
 
 .modal.fade#staticBackdrop{ 'data-bs-backdrop': "static", 'data-bs-keyboard':"false", 'tabindex': "-1", 'aria-labelledby': "staticBackdropLabel", 'aria-hidden': "true" }
   .modal-dialog

--- a/spec/features/user_visit_habits_page_spec.rb
+++ b/spec/features/user_visit_habits_page_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'User visit habits page', type: :feature do
+  let!(:user) { create(:user) }
+
+  background do
+    sign_in user
+  end
+
+  describe 'with a habit saved' do
+    let!(:habit) { create(:habit, user: user) }
+
+    scenario 'can see the active habit' do
+      visit habits_path
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content habit.name
+    end
+
+    scenario 'can see a message that has no archived habits' do
+      visit habits_path
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "You don't have completed habits yet."
+    end
+  end
+
+  describe 'user without a habit saved' do
+    scenario 'can see a message that has no saved habits' do
+      visit habits_path
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content "You don't have active habits yet."
+    end
+  end
+end

--- a/spec/requests/habits_spec.rb
+++ b/spec/requests/habits_spec.rb
@@ -1,48 +1,56 @@
 require 'rails_helper'
 
-RSpec.describe "Habits", type: :request do
+RSpec.describe 'Habits', type: :request do
   let(:user) { create(:user) }
   before(:each) { sign_in user }
 
-  describe "GET /index" do
-    it "returns http success" do
-      get "/habits"
+  describe 'GET /index' do
+    it 'returns http success' do
+      get habits_path
       expect(response).to have_http_status(:success)
+    end
+
+    context 'with a habit saved' do
+      let!(:habit) { create(:habit, user: user) }
+
+      it 'show active habit' do
+        get habits_path
+        expect(response.body).to include(habit.name)
+      end
+    end
+
+    context 'without a habit saved' do
+      it "show message You don't have any habits yet." do
+        get habits_path
+        expect(response.body).to include('You don&#39;t have active habits yet.')
+      end
     end
   end
 
-  describe "GET /habits/:id" do
-    it "returns a http success" do
-      habit = create(:habit)
-      get habit_path(habit.id)
-      expect(response).to have_http_status(:success)
+  describe 'POST /habits' do
+    context 'with valid attributes'
+    it 'saves a habit in the database' do
+      expect  do
+        post habits_path, params: { habit: attributes_for(:habit, user: user).merge(habit_duration: rand(21..66)) }
+      end.to change(Habit, :count).by(1)
+    end
+
+    it 'redirects to habit#show' do
+      post habits_path, params: { habit: attributes_for(:habit, user: user).merge(habit_duration: rand(21..66)) }
+      expect(response).to redirect_to habit_path(assigns(:habit).id)
     end
   end
 
-  describe "POST /habits" do
-    context "with valid attributes"
-      it "saves a habit in the database" do
-        expect{
-          post habits_path, params: { habit: attributes_for(:habit, user: user).merge(habit_duration: rand(21..66)) }
-        }.to change(Habit, :count).by(1)
-      end
-
-      it "redirects to habit#show" do
-        post habits_path, params: { habit: attributes_for(:habit, user: user).merge(habit_duration: rand(21..66))}
-        expect(response).to redirect_to habit_path(assigns(:habit).id)
-      end
-    end
-    
-    context "with invalid attributes" do
-      it "does not save the habit in the database" do
-        expect{
-          post habits_path, params: { habit: attributes_for(:habit, user: user, name: nil) }
-        }.not_to change(Habit, :count)
-      end
-
-      it "re-renders the index template" do
+  context 'with invalid attributes' do
+    it 'does not save the habit in the database' do
+      expect do
         post habits_path, params: { habit: attributes_for(:habit, user: user, name: nil) }
-        expect(response).to render_template :index
-      end
+      end.not_to change(Habit, :count)
     end
+
+    it 're-renders the index template' do
+      post habits_path, params: { habit: attributes_for(:habit, user: user, name: nil) }
+      expect(response).to redirect_to(habits_path)
+    end
+  end
 end


### PR DESCRIPTION
## Explain why this change is being made.
As a registered user, i would like to see a list of my current habits so i can track them

## Explain how this is accomplished.
the registered user with saved habits, enters the page and can see the list of habits he has saved.

## How do you manually test this?
- As a registered user with habits saved.
- Visit the page /habits.
- The page should show a list of your habits.

## Screenshots
![Screenshot from 2021-04-06 16-17-19](https://user-images.githubusercontent.com/36525675/113779667-af779080-96f3-11eb-818a-f39f0dedba07.png)
![Screenshot from 2021-04-06 16-17-39](https://user-images.githubusercontent.com/36525675/113779669-b0102700-96f3-11eb-8ad1-00e834eb9db1.png)
