### PR TITLE
Feature/habit notes

### DIFF
--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -1,6 +1,3 @@
-// Place all the styles related to the Habits controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
 #calendarContainer,
 #organizerContainer {
   display: flex;

--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -3,8 +3,6 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 #calendarContainer,
 #organizerContainer {
-  // float: left;
-  // margin: 5px;
   display: flex;
   flex-wrap: wrap;
 }
@@ -14,8 +12,10 @@
 }
 
 .day {
-  width: 60px;
-  height: 60px;
+  width: 30px;
+  height: 30px;
+  margin: 15px;
+  position: relative;
 }
 
 .month {
@@ -82,4 +82,21 @@
   background-color: #292c7b;
   border: none;
   transition: all 200ms ease-in;
+}
+
+.current-day {
+  border-radius: 50%;
+  background-color: rgba(232, 66,90,0.3);
+  width: 30px;
+  height: 30px;
+}
+
+.had-note {
+  position: absolute;
+  bottom: -10px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  background-color: #292c7b;
+  border-radius: 50%;
 }

--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -3,8 +3,27 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 #calendarContainer,
 #organizerContainer {
-  float: left;
-  margin: 5px;
+  // float: left;
+  // margin: 5px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.carousel-inner {
+  padding: 10%;
+}
+
+.day {
+  width: 60px;
+  height: 60px;
+}
+
+.month {
+  width: 100%;
+}
+
+.day:hover {
+  cursor: pointer;
 }
 
 .tooltip > .tooltip-inner {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,6 +1,3 @@
-// Place all the styles related to the home controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
 body a {
   text-decoration: none;
   color: rgb(255, 255, 255);

--- a/app/assets/stylesheets/note.scss
+++ b/app/assets/stylesheets/note.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the note controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/note.scss
+++ b/app/assets/stylesheets/note.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the note controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -1,0 +1,9 @@
+class DaysController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    respond_to do |format|
+      format.js
+    end
+  end
+end

--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -2,6 +2,8 @@ class DaysController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    @day_habit = Day.find(params[:id])
+    @note = @day_habit.note
     respond_to do |format|
       format.js
     end

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -22,6 +22,7 @@ class HabitsController < ApplicationController
 
   def set_habit
     @habit = Habit.find(params[:id])
+    @note = Note.new
   end
 
   def end_date_param

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -21,13 +21,11 @@ class HabitsController < ApplicationController
     @habit = Habit.find(params[:id])
     @note = Note.new
     @day_habit = day_habit(@habit)
-    @day_note = @day_habit.note
+    @day_note = @day_habit.note if @day_note
   end
 
   def day_habit(habit)
-    days = DaysQuery.new(@habit).today
-    day_habit = days[0] if days[0]
-    day_habit
+    DaysQuery.new(@habit).today.first
   end
 
   def end_date_param

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,5 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_habit, only: %i[show]
 
   def index
     @habit = Habit.new
@@ -18,11 +17,17 @@ class HabitsController < ApplicationController
     end
   end
 
-  def show; end
-
-  def set_habit
+  def show
     @habit = Habit.find(params[:id])
     @note = Note.new
+    @day_habit = day_habit(@habit)
+    @day_note = @day_habit.note
+  end
+
+  def day_habit(habit)
+    days = DaysQuery.new(@habit).today
+    day_habit = days[0] if days[0]
+    day_habit
   end
 
   def end_date_param

--- a/app/controllers/note_controller.rb
+++ b/app/controllers/note_controller.rb
@@ -4,11 +4,12 @@ class NoteController < ApplicationController
     @note = Note.create(description: params[:description], noteable: day_habit)
     if @note.valid?
       flash[:success] = "Note saved"
+      respond_to do |format|
+        format.js
+      end
     else 
       flash[:danger] = "Note not saved"
-      respond_to do |format|
-        format.html
-      end
+      render habit_path(day_habit.habit_id)
     end
   end
 end

--- a/app/controllers/note_controller.rb
+++ b/app/controllers/note_controller.rb
@@ -15,8 +15,8 @@ class NoteController < ApplicationController
 
   def update
     @note = Note.find(params[:id])
-    @note.update(description: params[:description])
-    if @note.valid?
+    @note.description = params[:description]
+    if @note.save
       flash[:success] = "Note updated"
       respond_to do |format|
         format.js
@@ -29,12 +29,9 @@ class NoteController < ApplicationController
 
   def destroy
     @note = Note.find(params[:id])
-    habit_id = @note.noteable.habit_id
     if @note.destroy
       flash[:success] = "Note deleted"
-      redirect_to habit_path(habit_id)
-    else 
-      flash[:danger] = "Note not deleted"
+      habit_id = @note.noteable.habit_id
       redirect_to habit_path(habit_id)
     end
   end

--- a/app/controllers/note_controller.rb
+++ b/app/controllers/note_controller.rb
@@ -12,4 +12,18 @@ class NoteController < ApplicationController
       render habit_path(day_habit.habit_id)
     end
   end
+
+  def update
+    @note = Note.find(params[:id])
+    @note.update(description: params[:description])
+    if @note.valid?
+      flash[:success] = "Note updated"
+      respond_to do |format|
+        format.js
+      end
+    else 
+      flash[:danger] = "Note not updated"
+      redirect_to habits_path
+    end
+  end
 end

--- a/app/controllers/note_controller.rb
+++ b/app/controllers/note_controller.rb
@@ -1,0 +1,14 @@
+class NoteController < ApplicationController
+  def create
+    day_habit = Day.find(params[:day_id])
+    @note = Note.create(description: params[:description], noteable: day_habit)
+    if @note.valid?
+      flash[:success] = "Note saved"
+    else 
+      flash[:danger] = "Note not saved"
+      respond_to do |format|
+        format.html
+      end
+    end
+  end
+end

--- a/app/controllers/note_controller.rb
+++ b/app/controllers/note_controller.rb
@@ -9,7 +9,7 @@ class NoteController < ApplicationController
       end
     else 
       flash[:danger] = "Note not saved"
-      render habit_path(day_habit.habit_id)
+      redirect_to habit_path(day_habit.habit_id)
     end
   end
 
@@ -24,6 +24,18 @@ class NoteController < ApplicationController
     else 
       flash[:danger] = "Note not updated"
       redirect_to habits_path
+    end
+  end
+
+  def destroy
+    @note = Note.find(params[:id])
+    habit_id = @note.noteable.habit_id
+    if @note.destroy
+      flash[:success] = "Note deleted"
+      redirect_to habit_path(habit_id)
+    else 
+      flash[:danger] = "Note not deleted"
+      redirect_to habit_path(habit_id)
     end
   end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,0 @@
-module HomeHelper
-end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,0 +1,3 @@
+class Day < ApplicationRecord
+  belongs_to :habit
+end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,3 +1,4 @@
 class Day < ApplicationRecord
   belongs_to :habit
+  has_one :note, as: :noteable
 end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,4 +1,4 @@
 class Day < ApplicationRecord
   belongs_to :habit
-  has_one :note, as: :noteable
+  has_one :note, as: :noteable, dependent: :destroy
 end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,4 +1,5 @@
 class Day < ApplicationRecord
   belongs_to :habit
   has_one :note, as: :noteable, dependent: :destroy
+  validates :date, presence: true
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -10,6 +10,7 @@ class Habit < ApplicationRecord
   
   def end_date_format
     self.end_date.to_s(:long) 
+  end
   private
 
   def add_days

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -1,5 +1,7 @@
 class Habit < ApplicationRecord
+  after_create :add_days
   belongs_to :user
+  has_many :days, dependent: :delete_all
   validates :name, :description, :start_date, :end_date, presence: true
 
   def start_date_format
@@ -8,5 +10,13 @@ class Habit < ApplicationRecord
   
   def end_date_format
     self.end_date.to_s(:long) 
+  private
+
+  def add_days
+    day = start_date
+    while day <= end_date
+      self.days.create(status: false, date: day)
+      day += 1.day
+    end
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note < ApplicationRecord
+  belongs_to :noteable, polymorphic: true
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,4 @@
 class Note < ApplicationRecord
   belongs_to :noteable, polymorphic: true
+  validates :description, presence: true
 end

--- a/app/queries/days_query.rb
+++ b/app/queries/days_query.rb
@@ -1,0 +1,11 @@
+class DaysQuery
+  attr_reader :days
+
+  def initialize(habit)
+    @days = habit.days
+  end
+
+  def today
+    @days.where(date: Date.today)
+  end
+end

--- a/app/queries/habits_query.rb
+++ b/app/queries/habits_query.rb
@@ -12,4 +12,8 @@ class HabitsQuery
   def archived
     @habits.where(status: true)
   end
+
+  def today
+    @habits.where()
+  end
 end

--- a/app/queries/habits_query.rb
+++ b/app/queries/habits_query.rb
@@ -12,8 +12,4 @@ class HabitsQuery
   def archived
     @habits.where(status: true)
   end
-
-  def today
-    @habits.where()
-  end
 end

--- a/app/views/days/show.js.erb
+++ b/app/views/days/show.js.erb
@@ -2,6 +2,7 @@ container = document.getElementById("note");
 note = document.getElementById("note-description");
 addNoteButton = document.getElementById("add-note-btn");
 editNoteButton = document.getElementById("edit-note-btn");
+deleteNoteButton = document.getElementById("delete-note-btn");
 formNote = document.getElementById("form-note");
 formEditNote = document.getElementById("form-edit-note");
 if("<%= @note %>") {
@@ -11,6 +12,11 @@ if("<%= @note %>") {
   if (!editNoteButton) {
     container.appendChild(editButtonNote());
   }
+
+  if (!deleteNoteButton) {
+    container.appendChild(deleteButtonNote());
+  }
+
   if (addNoteButton) {
     addNoteButton.remove();
   }
@@ -24,6 +30,10 @@ if("<%= @note %>") {
   if (editNoteButton) {
     editNoteButton.remove();
   }
+  if (deleteNoteButton) {
+    deleteNoteButton.remove();
+  }
+
 }
 
 function createButonNote() {
@@ -43,5 +53,15 @@ function editButtonNote() {
   button.setAttribute('data-bs-toggle', "modal");
   button.setAttribute('data-bs-target', "#staticBackdropEdit");
   button.innerText = "Edit the note";
+  return button;
+}
+
+function deleteButtonNote() { 
+  let button = document.createElement("a");
+  button.id = "delete-note-btn"
+  button.className = "btn btn-danger";
+  button.innerText = "Delete the note";
+  button.href = "/note/" + "<%= @note.id if @note %>";
+  button.setAttribute("data-method", "delete");
   return button;
 }

--- a/app/views/days/show.js.erb
+++ b/app/views/days/show.js.erb
@@ -1,18 +1,28 @@
 container = document.getElementById("note");
 note = document.getElementById("note-description");
-buttonFlag = document.getElementById("add-note-btn");
+addNoteButton = document.getElementById("add-note-btn");
+editNoteButton = document.getElementById("edit-note-btn");
 formNote = document.getElementById("form-note");
+formEditNote = document.getElementById("form-edit-note");
 if("<%= @note %>") {
   note.innerText = "<%= @note.description if @note %>";
-  if (buttonFlag) {
-    buttonFlag.remove();
+  formEditNote.action = '/days/' + "<%= @day_habit.id %>" + "/note/" + "<%= @note.id if @note %>";
+  formEditNote.setAttribute('data-remote', true);
+  if (!editNoteButton) {
+    container.appendChild(editButtonNote());
+  }
+  if (addNoteButton) {
+    addNoteButton.remove();
   }
 } else {
   note.innerText = "You don't have a note yet"
-  formNote.action = `/days/${<%= @day_habit.id %>}/note`;
+  formNote.action = "/days/" + "<%= @day_habit.id %>" + "/note";
   formNote.setAttribute('data-remote', true);
-  if (!buttonFlag) {
+  if (!addNoteButton) {
     container.appendChild(createButonNote());
+  }
+  if (editNoteButton) {
+    editNoteButton.remove();
   }
 }
 
@@ -23,5 +33,15 @@ function createButonNote() {
   button.setAttribute('data-bs-toggle', "modal");
   button.setAttribute('data-bs-target', "#staticBackdrop");
   button.innerText = "Add a note";
+  return button;
+}
+
+function editButtonNote() { 
+  let button = document.createElement("button");
+  button.id = "edit-note-btn"
+  button.className = "btn btn-secondary";
+  button.setAttribute('data-bs-toggle', "modal");
+  button.setAttribute('data-bs-target', "#staticBackdropEdit");
+  button.innerText = "Edit the note";
   return button;
 }

--- a/app/views/days/show.js.erb
+++ b/app/views/days/show.js.erb
@@ -10,6 +10,7 @@ if("<%= @note %>") {
 } else {
   note.innerText = "You don't have a note yet"
   formNote.action = `/days/${<%= @day_habit.id %>}/note`;
+  formNote.setAttribute('data-remote', true);
   if (!buttonFlag) {
     container.appendChild(createButonNote());
   }

--- a/app/views/days/show.js.erb
+++ b/app/views/days/show.js.erb
@@ -1,0 +1,26 @@
+container = document.getElementById("note");
+note = document.getElementById("note-description");
+buttonFlag = document.getElementById("add-note-btn");
+formNote = document.getElementById("form-note");
+if("<%= @note %>") {
+  note.innerText = "<%= @note.description if @note %>";
+  if (buttonFlag) {
+    buttonFlag.remove();
+  }
+} else {
+  note.innerText = "You don't have a note yet"
+  formNote.action = `/days/${<%= @day_habit.id %>}/note`;
+  if (!buttonFlag) {
+    container.appendChild(createButonNote());
+  }
+}
+
+function createButonNote() {
+  let button = document.createElement("button");
+  button.id = "add-note-btn"
+  button.className = "btn btn-primary";
+  button.setAttribute('data-bs-toggle', "modal");
+  button.setAttribute('data-bs-target', "#staticBackdrop");
+  button.innerText = "Add a note";
+  return button;
+}

--- a/app/views/habits/_form_edit_note.html.haml
+++ b/app/views/habits/_form_edit_note.html.haml
@@ -1,0 +1,7 @@
+= form_with id: 'form-edit-note', method: :put do |form|
+  %div
+    = form.label :description, class: "form-label"
+    = form.text_field :description, class: "form-control", required: true
+    = form.hidden_field :notebale, value: @day_habit, class: "form-control"
+  %div
+    = form.submit 'Edit note', class: 'btn btn-primary my-4'

--- a/app/views/habits/_form_note.html.haml
+++ b/app/views/habits/_form_note.html.haml
@@ -1,0 +1,7 @@
+= form_with id: 'form-note' do |form|
+  %div
+    = form.label :description, class: "form-label"
+    = form.text_field :description, class: "form-control", required: true
+    = form.hidden_field :notebale, value: @day_habit, class: "form-control"
+  %div
+    = form.submit 'Create note', class: 'btn btn-primary my-4'

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -32,3 +32,15 @@
         %small.text-muted A habit takes between 21 and 66 days to generate
       .modal-footer
         %button#close-btn.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
+
+.modal.fade#staticBackdropEdit{ 'data-bs-backdrop': "static", 'data-bs-keyboard':"false", 'tabindex': "-1", 'aria-labelledby': "staticBackdropLabel", 'aria-hidden': "true" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %h5.modal-title#staticBackdropLabel Edit habit
+        %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
+      .modal-body
+        = render 'form_edit_note', note: @note
+        %small.text-muted A habit takes between 21 and 66 days to generate
+      .modal-footer
+        %button#close-btn.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -5,7 +5,19 @@
     .row.mt-4
       %p.col-6.text-center= "Start: #{@habit.start_date_format}"
       %p.col-6.text-center= "End: #{@habit.end_date_format}"
-    .d-flex.justify-content-center.flex-wrap
-      #calendarContainer
-      #organizerContainer
+    #calendarContainer.w-100
+      - month = @habit.days.first.date.strftime('%B')
+      %h5.month= month
+      - @habit.days.each do |day|
+        - unless day.date.strftime('%B') == month
+          %h5.month= month = day.date.strftime('%B')
+        = link_to day.date.strftime('%d'), day, remote: true, class: 'day'
+    #organizerContainer
+    - if @habit.end_date >= Date.today
+      .note
+        %h6 Note
+        %p.note-description this is a note
+      .checkpoint
+        %h6 Checkpoint
+        %p.checkpoint-description this is a checkpoint
 = link_to "Get back to main page", habits_path

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -16,7 +16,7 @@
     - if @habit.end_date >= Date.today
       %h6 Note
       #note
-        %p#note-description this is a note
+        %p#note-description #{@day_note ? @day_note.description : 'You don\'t have a note yet'}
       .checkpoint
         %h6 Checkpoint
         %p.checkpoint-description this is a checkpoint

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -14,10 +14,22 @@
         = link_to day.date.strftime('%d'), day, remote: true, class: 'day'
     #organizerContainer
     - if @habit.end_date >= Date.today
-      .note
-        %h6 Note
-        %p.note-description this is a note
+      %h6 Note
+      #note
+        %p#note-description this is a note
       .checkpoint
         %h6 Checkpoint
         %p.checkpoint-description this is a checkpoint
+
+.modal.fade#staticBackdrop{ 'data-bs-backdrop': "static", 'data-bs-keyboard':"false", 'tabindex': "-1", 'aria-labelledby': "staticBackdropLabel", 'aria-hidden': "true" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %h5.modal-title#staticBackdropLabel Create a new habit
+        %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
+      .modal-body
+        = render 'form_note', day_habit: @day_habit, note: Note.new
+        %small.text-muted A habit takes between 21 and 66 days to generate
+      .modal-footer
+        %button.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
 = link_to "Get back to main page", habits_path

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -11,7 +11,7 @@
       - @habit.days.each do |day|
         - unless day.date.strftime('%B') == month
           %h5.month= month = day.date.strftime('%B')
-        = link_to day.date.strftime('%d'), day, remote: true, class: 'day'
+        = link_to day.date.strftime('%d'), day, remote: true, class: 'day', id: "#{month}-#{day.date.strftime('%d')}"
     #organizerContainer
     - if @habit.end_date >= Date.today
       %h6 Note
@@ -25,22 +25,22 @@
   .modal-dialog
     .modal-content
       .modal-header
-        %h5.modal-title#staticBackdropLabel Create a new habit
+        %h5.modal-title#staticBackdropLabel Create a new note
         %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
       .modal-body
         = render 'form_note', note: @note
         %small.text-muted A habit takes between 21 and 66 days to generate
       .modal-footer
-        %button#close-btn.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
+        %button#close-btn-add.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
 
 .modal.fade#staticBackdropEdit{ 'data-bs-backdrop': "static", 'data-bs-keyboard':"false", 'tabindex': "-1", 'aria-labelledby': "staticBackdropLabel", 'aria-hidden': "true" }
   .modal-dialog
     .modal-content
       .modal-header
-        %h5.modal-title#staticBackdropLabel Edit habit
+        %h5.modal-title#staticBackdropLabel Edit note
         %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
       .modal-body
         = render 'form_edit_note', note: @note
         %small.text-muted A habit takes between 21 and 66 days to generate
       .modal-footer
-        %button#close-btn.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
+        %button#close-btn-edit.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -28,8 +28,7 @@
         %h5.modal-title#staticBackdropLabel Create a new habit
         %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
       .modal-body
-        = render 'form_note', day_habit: @day_habit, note: Note.new
+        = render 'form_note', note: @note
         %small.text-muted A habit takes between 21 and 66 days to generate
       .modal-footer
-        %button.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
-= link_to "Get back to main page", habits_path
+        %button#close-btn.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -11,7 +11,9 @@
       - @habit.days.each do |day|
         - unless day.date.strftime('%B') == month
           %h5.month= month = day.date.strftime('%B')
-        = link_to day.date.strftime('%d'), day, remote: true, class: 'day', id: "#{month}-#{day.date.strftime('%d')}"
+        .day
+          = link_to day.date.strftime('%d'), day, remote: true, class: "#{'current-day' if Date.today == day.date} d-flex justify-content-center align-items-center", id: "#{month}-#{day.date.strftime('%d')}"
+          %div{class: "#{'had-note' if day.note}", 'data-bs-toggle': "#{'tooltip' if day.note}", 'data-bs-placement': "#{'bottom' if day.note}", 'title': "#{'You have a note' if day.note}"}
     #organizerContainer
     - if @habit.end_date >= Date.today
       %h6 Note

--- a/app/views/note/create.js.erb
+++ b/app/views/note/create.js.erb
@@ -1,3 +1,25 @@
 document.getElementById("add-note-btn").remove();
 document.getElementById("note-description").innerText = "<%= @note.description %>";
-document.getElementById("close-btn").click();
+document.getElementById("note").appendChild(editButtonNote());
+document.getElementById("note").appendChild(deleteButtonNote());
+document.getElementById("close-btn-add").click();
+
+function editButtonNote() { 
+  let button = document.createElement("button");
+  button.id = "edit-note-btn"
+  button.className = "btn btn-secondary";
+  button.setAttribute('data-bs-toggle', "modal");
+  button.setAttribute('data-bs-target', "#staticBackdropEdit");
+  button.innerText = "Edit the note";
+  return button;
+}
+
+function deleteButtonNote() { 
+  let button = document.createElement("a");
+  button.id = "delete-note-btn"
+  button.className = "btn btn-danger";
+  button.innerText = "Delete the note";
+  button.href = "/note/" + "<%= @note.id if @note %>";
+  button.setAttribute("data-method", "delete");
+  return button;
+}

--- a/app/views/note/create.js.erb
+++ b/app/views/note/create.js.erb
@@ -1,0 +1,3 @@
+document.getElementById("add-note-btn").remove();
+document.getElementById("note-description").innerText = "<%= @note.description %>";
+document.getElementById("close-btn").click();

--- a/app/views/note/update.js.erb
+++ b/app/views/note/update.js.erb
@@ -1,1 +1,2 @@
 document.getElementById("note-description").innerText = "<%= @note.description %>";
+document.getElementById("close-btn-edit").click();

--- a/app/views/note/update.js.erb
+++ b/app/views/note/update.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("note-description").innerText = "<%= @note.description %>";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
     get 'profile', to: 'users/registrations#show'
   end
   resources :habits, only: %i[index create show]
+  resources :days
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   resources :habits, only: %i[index create show]
   resources :days do
-    resources :note
+    resources :note, only: %i[create update]
   end
+  resources :note, only: %i[destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
     get 'profile', to: 'users/registrations#show'
   end
   resources :habits, only: %i[index create show]
-  resources :days
+  resources :days do
+    resources :note
+  end
 end

--- a/db/migrate/20210408023613_create_days.rb
+++ b/db/migrate/20210408023613_create_days.rb
@@ -1,0 +1,12 @@
+class CreateDays < ActiveRecord::Migration[6.1]
+  def change
+    create_table :days do |t|
+      t.boolean :status
+      t.text :description
+      t.date :date
+      t.references :habit, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210408171115_create_notes.rb
+++ b/db/migrate/20210408171115_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notes do |t|
+      t.string :description
+      t.references :noteable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210408171556_add_default_status_to_day.rb
+++ b/db/migrate/20210408171556_add_default_status_to_day.rb
@@ -1,0 +1,5 @@
+class AddDefaultStatusToDay < ActiveRecord::Migration[6.1]
+  def change
+    change_column :days, :status, :boolean, default: false
+  end
+end

--- a/db/migrate/20210409173052_remove_description_from_days.rb
+++ b/db/migrate/20210409173052_remove_description_from_days.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromDays < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :days, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_08_171556) do
+ActiveRecord::Schema.define(version: 2021_04_09_173052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "days", force: :cascade do |t|
     t.boolean "status", default: false
-    t.text "description"
     t.date "date"
     t.bigint "habit_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_08_023613) do
+ActiveRecord::Schema.define(version: 2021_04_08_171556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "days", force: :cascade do |t|
-    t.boolean "status"
+    t.boolean "status", default: false
     t.text "description"
     t.date "date"
     t.bigint "habit_id", null: false
@@ -35,6 +35,15 @@ ActiveRecord::Schema.define(version: 2021_04_08_023613) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_habits_on_user_id"
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.string "description"
+    t.string "noteable_type", null: false
+    t.bigint "noteable_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["noteable_type", "noteable_id"], name: "index_notes_on_noteable"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_234210) do
+ActiveRecord::Schema.define(version: 2021_04_08_023613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "days", force: :cascade do |t|
+    t.boolean "status"
+    t.text "description"
+    t.date "date"
+    t.bigint "habit_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["habit_id"], name: "index_days_on_habit_id"
+  end
 
   create_table "habits", force: :cascade do |t|
     t.string "name"
@@ -42,5 +52,6 @@ ActiveRecord::Schema.define(version: 2021_03_31_234210) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "days", "habits"
   add_foreign_key "habits", "users"
 end

--- a/spec/factories/days.rb
+++ b/spec/factories/days.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :day do
+    status { rand(1..100) > 50 }
+    date { Faker::Date.forward(days: 1) }
+    association :habit
+  end
+end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :note do
+    description { Faker::Lorem.paragraph }
+    association :noteable, factory: :day
+  end
+end

--- a/spec/features/crud_note_spec.rb
+++ b/spec/features/crud_note_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.feature "CRUD Notes", type: :feature, js: true do
+  let(:user) { create(:user) }
+  let(:habit) { create(:habit) }
+  let(:note) { attributes_for(:note) }
+
+  context "with an authenticated user" do
+    before(:each) { sign_in user }
+
+    scenario "create a new note" do
+      visit habits_path
+      click_button 'Add New Habit'
+
+      fill_in 'Name', with: habit[:name]
+      fill_in 'Description', with: habit[:description]
+      fill_in 'Start date', with: habit[:start_date]
+      fill_in 'Habit duration', with: rand(22..66)
+      click_button 'Create habit'
+      find("##{Date.today.strftime('%B')}-#{Date.today.day + 1}").click
+      expect(page).to have_content "You don't have a note yet"
+
+      click_button "Add a note"
+      fill_in 'Description', with: note[:description]
+      click_button "Create note"
+
+      expect(page).to have_content note[:description]
+    end
+
+    scenario "a new note can not be saved with an invalid description" do
+      visit habits_path
+      click_button 'Add New Habit'
+
+      fill_in 'Name', with: habit[:name]
+      fill_in 'Description', with: habit[:description]
+      fill_in 'Start date', with: habit[:start_date]
+      fill_in 'Habit duration', with: rand(22..66)
+      click_button 'Create habit'
+      find("##{Date.today.strftime('%B')}-#{Date.today.day + 2}").click
+      expect(page).to have_content "You don't have a note yet"
+
+      click_button "Add a note"
+      fill_in 'Description', with: ""
+      click_button "Create note"
+      message = page.find("#description").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+
+    scenario "edit a note recently saved" do
+      visit habit_path(habit.id)
+      day = habit.days.first
+      note = create(:note, noteable: day)
+
+      find("##{day.date.strftime('%B')}-#{day.date.day}").click
+
+      click_button "Edit the note"
+      fill_in "Description", with: "New note"  
+      click_button "Edit note", wait: 5
+
+      expect(page).to have_content("New note")
+    end
+
+    scenario "delete a note" do
+      habit = create(:habit, user: user)
+      day = habit.days.first
+      note = create(:note, noteable: day)
+      visit habit_path(habit.id)
+      find("##{day.date.strftime('%B')}-#{day.date.day}").click
+ 
+      click_link "Delete the note"
+      expect(page).to have_content("Note deleted")
+    end
+
+    scenario "add a note after delete the note" do
+      habit = create(:habit, user: user)
+      day = habit.days.first
+      note = create(:note, noteable: day)
+      visit habit_path(habit.id)
+      find("##{day.date.strftime('%B')}-#{day.date.day}").click
+ 
+      click_link "Delete the note"
+      expect(page).to have_content("Note deleted")
+
+      find("##{day.date.strftime('%B')}-#{day.date.day}").click
+      click_button "Add a note"
+      fill_in 'Description', with: note[:description]
+      click_button "Create note"
+
+      expect(page).to have_content note[:description]
+    end
+  end
+end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Day, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Day, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:day) }
+
+  describe 'associations' do
+    it { should belong_to(:habit) }
+  end
+
+  describe 'validations' do
+    it 'is valid with a status and a date' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid without a date' do
+      day_habit = build(:day, date: nil)
+      day_habit.valid?
+      expect(day_habit.errors[:date]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Habit, type: :model do
 
   describe 'associations' do
     it { should belong_to(:user) }
+    it { should have_many(:days)}
   end
 
   describe 'validations' do

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Note, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:habit) { create(:habit) }
+  let(:day) { create(:day, habit: habit) }
+  subject { create(:note, noteable: day) }
+
+  describe 'validations' do
+    it 'is valid with a description' do
+      expect(subject).to be_valid
+    end
+
+    it 'is invalid without a description' do
+      note = build(:note, description: nil)
+      note.valid?
+      expect(note.errors[:description]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/requests/days_spec.rb
+++ b/spec/requests/days_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Days', type: :request do
+  let(:user) { create(:user) }
+  before(:each) { sign_in user }
+  let(:habit) { create(:habit, user: user) }
+  let(:day) { create(:day, habit: habit) }
+  let(:note) { create(:note, noteable: day) }
+
+  describe 'SHOW /days/id' do
+    it 'it gets the note attach' do
+      get "/days/#{day.id}.js", xhr: true
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/habits_spec.rb
+++ b/spec/requests/habits_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Habits', type: :request do
       let!(:habit) { create(:habit, user: user) }
 
       it 'show active habit' do
-        get habits_path
+        get habit_path(habit)
         expect(response.body).to include(habit.name)
       end
     end

--- a/spec/requests/note_spec.rb
+++ b/spec/requests/note_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Notes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/note_spec.rb
+++ b/spec/requests/note_spec.rb
@@ -1,7 +1,84 @@
 require 'rails_helper'
 
 RSpec.describe "Notes", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  before(:each) { sign_in user } 
+  let(:habit) { create(:habit, user: user) }
+  let(:day) { create(:day, habit: habit) }
+
+  describe 'POST /days/:id/note' do
+    context 'with valid attributes'
+    it 'saves a note in the database' do
+      expect  do
+        post day_note_index_path(day), params: { description: build(:note).description }, xhr: true
+      end.to change(Note, :count).by(1)
+    end
+
+    it 'redirects to create.js' do
+      post day_note_index_path(day), params: { description: build(:note).description },  xhr: true
+      expect(response).to have_http_status(:success)
+    end
   end
+
+  context 'with invalid attributes' do
+    it 'does not save a note in the database' do
+      expect do
+        post day_note_index_path(day), params: { description: nil }
+      end.not_to change(Note, :count)
+    end
+
+    it 'redirect_to the habit details template' do
+      post day_note_index_path(day), params: { description: nil }
+      expect(response).to redirect_to(habit_path(habit))
+    end
+  end
+
+  describe 'PUT /days/:id/note/:id' do
+    before(:each) do
+      @note = create(:note, noteable: day)
+      @attributes = attributes_for(:note)
+    end
+    context 'with valid attributes' do
+      it 'saves a note in the database' do
+        patch day_note_path(day, @note), params: { description: @attributes['description'] }, xhr: true
+        expect(assigns(:note).description).to eq(@attributes['description'])
+      end
+
+      it 'redirects to update.js' do
+        patch day_note_path(day, @note, format: :js), params: { description: @attributes['description'] }, xhr: true
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'does not save a note in the database' do
+        patch day_note_path(day, @note), params: { description: nil }
+        @note.reload
+        expect(@note.description).not_to eq(Faker::Lorem.paragraph)
+      end
+
+      it 'redirect_to the habit details template' do
+        patch day_note_path(day, @note), params: { description: @attributes['description'] }
+        expect(response).to redirect_to habits_path
+      end
+    end
+  end
+
+  describe 'DELETE /note/:id' do
+    before(:each) do
+      @note = create(:note, noteable: day)
+    end
+    
+    it 'delete the note from the database' do
+      expect {
+        delete note_path(@note)
+      }.to change(Note, :count).by(-1)
+    end
+
+    it 'redirects to habits_path' do
+      delete note_path(@note)
+      expect(response).to redirect_to habit_path(@note.noteable.habit_id)
+    end
+  end
+
 end


### PR DESCRIPTION
## Explain why this change is being made.
As a registered user with active habits, I want to see the notes of a specific day of the habit, so that I can see all the notes about the habit.

## Explain how this is accomplished.
Once a habit is created, you could see the list of the days duration of the habit, you could press over each day to add, edit o remove a note

## How do you manually test this?
  - Given the user is logged in, you can press the link Habits over the navbar, then click on 'Add new habit', fill all the form, an once the habit is created you will be redirected to the details page of the habit
  - Once you see the habit details page, if you ever had a note this will show a little blue button, also the calendar will show the current date with a circle painted on the day. 
  - Press the day, and if you do not have a note, then you could add a note, if you already have a note, then you could edit or delete the note

### Screenshots
![image](https://user-images.githubusercontent.com/32284972/114427131-022fcd00-9b78-11eb-97bc-b2aea90a18dc.png)
![image](https://user-images.githubusercontent.com/32284972/114427242-24294f80-9b78-11eb-8b62-cff069a3eba9.png)
![image](https://user-images.githubusercontent.com/32284972/114427288-2db2b780-9b78-11eb-844e-d6b013595544.png)
![image](https://user-images.githubusercontent.com/32284972/114427321-360af280-9b78-11eb-95dd-b38dd324edd8.png)
![image](https://user-images.githubusercontent.com/32284972/114427352-3c996a00-9b78-11eb-91e8-6f52d18bac74.png)
![image](https://user-images.githubusercontent.com/32284972/114427421-4f13a380-9b78-11eb-8c71-75d128dfb687.png)
