### PR TITLE
Feature/edit habit

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -18,3 +18,11 @@ body .btn-primary{
 body .btn-primary:hover{
   background-color: rgb(194, 54, 73);
 }
+
+.navbar {
+  background-color: rgb(41,42,123);
+}
+
+#nav-logo {
+  color: rgb(255, 255, 255);
+}

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,5 +1,6 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_habit, only: %i[show edit update]
 
   def index
     @habit = Habit.new
@@ -17,7 +18,21 @@ class HabitsController < ApplicationController
     end
   end
 
-  def show
+  def show; end
+
+  def edit; end
+
+  def update
+    if @habit.update(habit_params)
+      flash[:success] = 'Habit updated successfully'
+      redirect_to @habit
+    else
+      flash[:danger] = 'Error habit did not update'
+      redirect_to habits_path
+    end
+  end
+
+  def set_habit
     @habit = Habit.find(params[:id])
     @note = Note.new
     @day_habit = day_habit(@habit)
@@ -31,7 +46,11 @@ class HabitsController < ApplicationController
   def end_date_param
     raise MissingAttributeError unless params[:habit][:habit_duration]
 
-    params[:habit][:start_date].to_date + params[:habit][:habit_duration].to_i.days
+    if (params[:_method] === 'patch')
+      @habit.start_date.to_date + params[:habit][:habit_duration].to_i.days
+    else
+      params[:habit][:start_date].to_date + params[:habit][:habit_duration].to_i.days
+    end
   rescue StandardError
     flash[:info] = 'Invalid form'
   end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -1,5 +1,6 @@
 class Habit < ApplicationRecord
   after_create :add_days
+  after_update :add_days, :clean_unused_days
   belongs_to :user
   has_many :days, dependent: :delete_all
   has_many :checkpoints, dependent: :delete_all
@@ -8,7 +9,7 @@ class Habit < ApplicationRecord
   def start_date_format
     self.start_date.to_s(:long) 
   end
-  
+
   def end_date_format
     self.end_date.to_s(:long) 
   end
@@ -22,13 +23,21 @@ class Habit < ApplicationRecord
     day ? day : days.first
   end
 
+  def clean_unused_days
+    day = self.end_date
+    loop do
+      self.days.where(date: day).exists? ? self.days.find_by(date: day).destroy : day += 1.day 
+      break if  day >= saved_change_to_end_date.first
+    end
+  end
+
   private
 
   def add_days
     day = start_date
-    while day <= end_date
-      self.days.create(status: false, date: day)
-      day += 1.day
+    loop do
+      self.days.where(date: day).exists? ? day += 1.day : (self.days.create(status: false, date: day) &&  day += 1.day)
+      break if day >= end_date
     end
   end
 end

--- a/app/views/habits/_form.html.haml
+++ b/app/views/habits/_form.html.haml
@@ -4,9 +4,9 @@
     = form.text_field :name, class: "form-control", required: true
     = form.label :description, class: "form-label"
     = form.text_field :description, class: "form-control", required: true
-    = form.label :start_date, class: "form-label mt-4"
-    = form.date_field :start_date, class: "form-control", required: true, min: Date.today
+    = form.label :start_date, class: "form-label mt-4" if @habit.new_record?
+    = form.date_field :start_date, class: "form-control", required: true, min: Date.today if @habit.new_record?
     = form.label :habit_duration, class: "form-label"
     = form.number_field :habit_duration, in: 21..66, class: "form-control", required: true 
   %div
-    = form.submit 'Create habit', class: 'btn btn-primary my-4'
+    = form.submit class: 'btn btn-primary my-4'

--- a/app/views/habits/_habit.html.haml
+++ b/app/views/habits/_habit.html.haml
@@ -8,3 +8,4 @@
       %p.m-0
         %strong Checkpoints:
       %div.d-flex.overflow-auto
+      =link_to '', habit, class: 'stretched-link'

--- a/app/views/habits/_habit.html.haml
+++ b/app/views/habits/_habit.html.haml
@@ -8,4 +8,4 @@
       %p.m-0
         %strong Checkpoints:
       %div.d-flex.overflow-auto
-      =link_to '', habit, class: 'stretched-link'
+        =link_to '', habit, id: "link-habit-#{habit.id}", class: 'stretched-link'

--- a/app/views/habits/show.html.haml
+++ b/app/views/habits/show.html.haml
@@ -1,3 +1,18 @@
+.d-flex.justify-content-end.mb-3
+  %button.btn.btn-primary.ml-auto{ 'type': 'button', 'data-bs-toggle': 'modal', 'data-bs-target': '#staticBackdrop'} Edit Habit
+
+.modal.fade#staticBackdrop{ 'data-bs-backdrop': "static", 'data-bs-keyboard':"false", 'tabindex': "-1", 'aria-labelledby': "staticBackdropLabel", 'aria-hidden': "true" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %h5.modal-title#staticBackdropLabel Edit habit
+        %button.btn-close{ 'type': "button", 'data-bs-dismiss': "modal", 'aria-label': "Close" }
+      .modal-body
+        = render 'form', habit: @habit
+        %small.text-muted A habit takes between 21 and 66 days to generate
+      .modal-footer
+        %button.btn.btn-secondary{ 'type':"button", 'data-bs-dismiss': "modal"} Close
+
 .card.mt-4.p-3
   .card-body
     %h4.card-title= "Habit: #{@habit.name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     get 'profile', to: 'users/registrations#show'
   end
-  resources :habits, only: %i[index create show]
+  resources :habits, only: %i[index create show edit update]
   resources :days do
     resources :note, only: %i[create update]
     resources :checkpoint

--- a/spec/features/create_new_habit_spec.rb
+++ b/spec/features/create_new_habit_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: habit[:description]
       fill_in 'Start date', with: habit[:start_date]
       fill_in 'Habit duration', with: rand(22..66)
-      click_button 'Create habit'
+      click_button 'Create Habit'
       expect(page).to have_content habit[:name]
     end
 
@@ -28,7 +28,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: habit[:description]
       fill_in 'Start date', with: habit[:start_date]
       fill_in 'Habit duration', with: rand(22..66)
-      click_button 'Create habit'
+      click_button 'Create Habit'
       expect(page).to have_content habit[:name]
       expect(page).to have_content habit[:description]
       expect(page).to have_content habit[:start_date].to_s(:long)
@@ -43,7 +43,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: habit[:description]
       fill_in 'Start date', with: habit[:start_date]
       fill_in 'Habit duration', with: rand(21..66)
-      click_button 'Create habit'
+      click_button 'Create Habit'
       message = page.find("#habit_name").native.attribute("validationMessage")
       expect(message).to eq "Please fill out this field."
     end
@@ -57,7 +57,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: nil
       fill_in 'Start date', with: habit[:start_date]
       fill_in 'Habit duration', with: rand(21..66)
-      click_button 'Create habit'
+      click_button 'Create Habit'
       message = page.find("#habit_description").native.attribute("validationMessage")
       expect(message).to eq "Please fill out this field."
     end
@@ -71,7 +71,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: habit[:description]
       fill_in 'Start date', with: nil
       fill_in 'Habit duration', with: rand(21..66)
-      click_button 'Create habit'
+      click_button 'Create Habit'
       message = page.find("#habit_start_date").native.attribute("validationMessage")
       expect(message).to eq "Please fill out this field."
     end
@@ -85,7 +85,7 @@ RSpec.feature "CreateNewHabits", type: :feature do
       fill_in 'Description', with: habit[:description]
       fill_in 'Start date', with: habit[:start_date]
       fill_in 'Habit duration', with: nil
-      click_button 'Create habit'
+      click_button 'Create Habit'
       message = page.find("#habit_habit_duration").native.attribute("validationMessage")
       expect(message).to eq "Please fill out this field."
     end

--- a/spec/features/edit_habit_spec.rb
+++ b/spec/features/edit_habit_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.feature "Edit a habit", type: :feature do
+  let!(:user) { create(:user) }
+  let!(:habit) { create(:habit, user: user) }
+
+  context "with an authenticated user" do
+    before(:each) { sign_in user }
+
+    scenario "edit a habit" do
+      visit habits_path
+      page.find(:xpath, "//a[@href=" + "'" + "/habits/#{habit.id}" + "'" + "]").click
+      expect(page).to have_content habit[:name]
+      click_button 'Edit Habit'
+      fill_in 'Name', with: habit[:name]
+      fill_in 'Habit duration', with: rand(22..66)
+      click_button 'Update Habit'
+      expect(page).to have_content 'Habit updated successfully'
+    end
+
+    scenario "see his habit data in the edit form" do
+      visit habits_path
+      page.find(:xpath, "//a[@href=" + "'" + "/habits/#{habit.id}" + "'" + "]").click
+      expect(page).to have_content habit[:name]
+      click_button 'Edit Habit'
+      expect(page).to have_content habit[:name]
+      expect(page).to have_content habit[:description]
+      expect(page).to have_content habit[:name]
+    end
+
+    scenario "edits a habit with an invalid name", js: true do
+      visit habit_path(habit)
+      click_button 'Edit Habit'
+      fill_in 'Name', with: ''
+      fill_in 'Description', with: habit[:description]
+      fill_in 'Habit duration', with: rand(21..66)
+      click_button 'Update Habit'
+      message = page.find("#habit_name").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+
+
+    scenario "edits a habit with an invalid description", js: true do
+      visit habit_path(habit)
+      click_button 'Edit Habit'
+      fill_in 'Name', with: habit[:name]
+      fill_in 'Description', with: nil
+      fill_in 'Habit duration', with: rand(21..66)
+      click_button 'Update Habit'
+      message = page.find("#habit_description").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+    
+    scenario "edits a habit with an invalid days quantity", js: true do
+      visit habit_path(habit)
+      click_button 'Edit Habit'
+      fill_in 'Name', with: habit[:name]
+      fill_in 'Description', with: habit[:description]
+      fill_in 'Habit duration', with: nil
+      click_button 'Update Habit'
+      message = page.find("#habit_habit_duration").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+  end
+
+  context "with a not authenticated user" do
+    scenario "cant access /habits/:id" do
+      visit habit_path(habit)
+      expect(page).to have_content 'Log in'
+    end
+  end
+end


### PR DESCRIPTION
## Explain why this change is being made.
As a user with active habits, i would like to be able to edit my habits information so i can change them

## Explain how this is accomplished.
When you are on habits index, you can click on each habit card to go to their show page, where you can edit it

## How do you manually test this?
-Scenario 1 - User is in /habits Given the user clicks on one of the habits card Then the user goes to /habit/:habit_id/ Then the user clicks on edit habit button Then a form appears, and the user fulfills the fields he would like to edit. The user can edit The habit name, The habit description and the Final date


### Screenshots
![image](https://user-images.githubusercontent.com/25086862/114448335-08827100-9b99-11eb-8c32-507e47712da8.png)

![image](https://user-images.githubusercontent.com/25086862/114448386-1c2dd780-9b99-11eb-8610-0f4740b6b077.png)

![image](https://user-images.githubusercontent.com/25086862/114448423-27810300-9b99-11eb-82e7-af69755cdede.png)

