### PR TITLE
Add timeline highlights for checkpoints

### DIFF
--- a/app/views/habits/_checkpoint.html.haml
+++ b/app/views/habits/_checkpoint.html.haml
@@ -1,0 +1,2 @@
+%li.timeline-item{class: [checkpoint.status && 'complete'], 'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "#{checkpoint.title}</br>#{checkpoint.due_date}</br>#{checkpoint.description}" }
+    .checkpoint

--- a/app/views/habits/_habit.html.haml
+++ b/app/views/habits/_habit.html.haml
@@ -1,11 +1,13 @@
 .col-xs-12.col-sm-6
   .card
-    .card-body
+    .card-body.pb-0.position-relative
       %h5.card-title= habit.name
       %p.card-text
         %strong Start date:
         = habit.start_date
+      =link_to '', habit, id: "link-habit-#{habit.id}", class: 'stretched-link'  
+    .card-body.pt-0
       %p.m-0
         %strong Checkpoints:
       %div.d-flex.overflow-auto
-        =link_to '', habit, id: "link-habit-#{habit.id}", class: 'stretched-link'
+        = render 'timeline', habit: habit

--- a/app/views/habits/_timeline.html.haml
+++ b/app/views/habits/_timeline.html.haml
@@ -1,11 +1,2 @@
 %ul.timeline.p-0.m-0#timeline
-  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
-    .checkpoint
-  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
-    .checkpoint
-  %li.timeline-item.complete{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses asd  asda" }
-    .checkpoint
-  %li.timeline-item{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses" }
-    .checkpoint
-  %li.timeline-item
-    .checkpoint{'data-bs-html': 'true', 'data-bs-toggle':"tooltip", 'data-bs-placement': "right", 'title': "Checkpoint 1</br>12/04/2021</br>Lorem ipsum modses" }
+  = render partial: 'checkpoint', collection: habit.checkpoints


### PR DESCRIPTION
Add timeline to show the checkpoint progress

## Explain why this change is being made.
As a registered user, i would like to see more information about my timeline highlights so i can have a better understanding of each of them

---

## Explain how this is accomplished.
the registered user with saved habits and checkpoints, enters the page and can see the list of habits he has saved with a timeline with the checkpoints.

- Given each card has a timeline
- Given the user hovers on any of the timeline highlights, 
- Then a tooltip is shown
  - The tooltip should have 
  - Name of the highlight
  - The date
  - Part of the description 


---

## How do you manually test this?
 1. As a registered user with habits saved.
 2. Visit the page /habits.
 3. Select an active habit to redirect to the habit details.
 4. Select a day and add a new checkpoint.
 5. Go back to the habits page.
 3. The habits page should show a timeline with the checkpoints.

---

## Screenshots
![pr](https://user-images.githubusercontent.com/36525675/115318126-b1edd780-a142-11eb-87ea-e7790d3e51eb.png)

