### PR TITLE
Feature/checkpoint notification

### DIFF
--- a/app/controllers/checkpoint_controller.rb
+++ b/app/controllers/checkpoint_controller.rb
@@ -9,8 +9,6 @@ class CheckpointController < ApplicationController
   def create
     @checkpoint = @day.build_checkpoint(checkpoint_params)
     if @checkpoint.save
-      # CheckpointMailer.with(user: current_user).checkpoint_expired.deliver_now
-      ExpiredCheckpointsJob.perform_now(current_user)
       respond_to :js
     else
       redirect_to @habit, danger: "Checkpoint not created"

--- a/app/controllers/checkpoint_controller.rb
+++ b/app/controllers/checkpoint_controller.rb
@@ -1,7 +1,7 @@
 class CheckpointController < ApplicationController
   before_action :set_day, only: %i[create update]
   before_action :set_habit, only: :update
-  before_action :set_checkpoint, only: %i[update destroy]
+  before_action :set_checkpoint, only: %i[update destroy toggle_status]
 
   def new
   end
@@ -28,6 +28,15 @@ class CheckpointController < ApplicationController
     @day = Day.find(@checkpoint.day_id)
     @checkpoint.destroy
     respond_to :js
+  end
+
+  def toggle_status
+    @checkpoint.toggle_status
+    if @checkpoint.save
+      respond_to :js
+    else
+      redirect_to @checkpoint.habit, danger: "Checkpoint wasn't checked correctly"
+    end
   end
 
   private

--- a/app/jobs/expired_checkpoints_job.rb
+++ b/app/jobs/expired_checkpoints_job.rb
@@ -2,10 +2,9 @@ class ExpiredCheckpointsJob < ApplicationJob
   queue_as :default
 
   def perform
-    unless get_expired_checkpoints.empty?
-      get_expired_checkpoints.each do |checkpoint|
-        CheckpointMailer.with(checkpoint: checkpoint).checkpoint_expired.deliver_later
-      end
+    return if get_expired_checkpoints.empty?
+    get_expired_checkpoints.each do |checkpoint|
+      CheckpointMailer.with(checkpoint: checkpoint).checkpoint_expired.deliver_later!
     end
   end
 

--- a/app/jobs/expired_checkpoints_job.rb
+++ b/app/jobs/expired_checkpoints_job.rb
@@ -1,7 +1,17 @@
 class ExpiredCheckpointsJob < ApplicationJob
   queue_as :default
 
-  def perform(user)
-    CheckpointMailer.with(user: user).checkpoint_expired.deliver_later
+  def perform
+    unless get_expired_checkpoints.empty?
+      get_expired_checkpoints.each do |checkpoint|
+        CheckpointMailer.with(checkpoint: checkpoint).checkpoint_expired.deliver_later
+      end
+    end
+  end
+
+  private
+
+  def get_expired_checkpoints
+    Checkpoint.expired
   end
 end

--- a/app/mailers/checkpoint_mailer.rb
+++ b/app/mailers/checkpoint_mailer.rb
@@ -2,8 +2,10 @@ class CheckpointMailer < ApplicationMailer
   default from: 'from@example.com'
 
   def checkpoint_expired
-    @user = params[:user]
-    @url  = root_url
+    @checkpoint = params[:checkpoint]
+    @habit = @checkpoint.habit
+    @user = @habit.user
+    @url  = habit_url(@habit)
     mail(to: @user.email, subject: 'Checkpoint expired')
   end
 end

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -6,11 +6,19 @@ class Checkpoint < ApplicationRecord
   validates :title, :description, :due_date, presence: true
   validate :due_date_within_dates_of_habit
 
-  private
+  def toggle_status
+    self.status = !status
+  end
 
   def self.expired
     where(due_date: Date.today)
   end
+
+  def able_to_be_checked?
+    due_date <= Date.today
+  end
+
+  private
 
   def due_date_within_dates_of_habit
     unless Habit.find(habit_id).has_date(due_date)

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -8,6 +8,10 @@ class Checkpoint < ApplicationRecord
 
   private
 
+  def self.expired
+    where(due_date: Date.today)
+  end
+
   def due_date_within_dates_of_habit
     unless Habit.find(habit_id).has_date(due_date)
       errors.add(:due_date, "should be within habit start date and end date")

--- a/app/views/checkpoint/_checkpoint.html.haml
+++ b/app/views/checkpoint/_checkpoint.html.haml
@@ -11,6 +11,14 @@
     - else
       %h5.card-title= checkpoint.title
       %p.card-text= checkpoint.description
+      - if checkpoint.able_to_be_checked?
+        .check-ckeckpoint.my-3
+          - if checkpoint.status
+            %p.text-success This checkpoint has been achieved!
+            = link_to 'Mark as not Achieved', checkpoint_toggle_path(checkpoint), remote: true, class: 'btn btn-primary btn-sm'
+          - else
+            %p.text-danger This checkpoint hasn't been achieved!
+            = link_to 'Mark as Achieved', checkpoint_toggle_path(checkpoint), remote: true, class: 'btn btn-success btn-sm'
       %button(type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#checkpoint-edit-form")
         Update
       = link_to 'Delete', day_checkpoint_path(day, checkpoint), method: :delete, remote: true, class: 'btn btn-warning btn-sm'

--- a/app/views/checkpoint/toggle_status.js.erb
+++ b/app/views/checkpoint/toggle_status.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('checkpoint-container').innerHTML = "<%= j render 'checkpoint/checkpoint', day: @checkpoint.day %>";

--- a/app/views/checkpoint_mailer/checkpoint_expired.html.haml
+++ b/app/views/checkpoint_mailer/checkpoint_expired.html.haml
@@ -1,4 +1,16 @@
 %h1 Expired checkpoint
-%p This checkpoint has expired
-%p= "To mark it as achieved or not, follow this link: #{@url}"
+%p
+  = "Hi #{@user.first_name} this is a reminder for a checkpoint that expires today\n"
+  This are the checkpoint details:
+
+%h3 Habit
+%p= "Name: #{@habit.name}"
+%p= "Description: #{@habit.description}"
+
+%h3= "The checkpoint '#{@checkpoint.title}' has expired"
+%p= "Checkpoint description: #{@checkpoint.description}"
+
+%p
+  To mark it as achieved or not, follow this link:&nbsp;
+  = link_to 'check checkpoint', @url
 %p Just remember to keep growing and have a good day!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
     resources :note, only: %i[create update]
     resources :checkpoint
   end
+  get 'checkpoint_toggle/:id', to: 'checkpoint#toggle_status', as: 'checkpoint_toggle'
   resources :note, only: %i[destroy]
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,2 +1,4 @@
 expired_checkpoints:
   class: "ExpiredCheckpointsJob"
+  cron: "0 12 * * * *" # execute daily at 12:00 pm
+


### PR DESCRIPTION
## Explain why this change is being made.
---
As a user with an upcoming checkpoint, I should receive a notification the day of that checkpoint.



## Explain how this is accomplished.
---
Scenario 1 - Today is the expired day of a checkpoint
- Given the user create a new checkpoint when the checkpoint expired then the application should send an email mentioning the checkpoint information
  - The email should include the checkpoint and habit details.
  - The email should include a link to redirect to the habit and can add a note to the checkpoint
  - Then the user can click on that link and go to that habit page and then the user can
    - Mark that checkpoint as achieved or not achieved 

## Screenshots
- Not achieved checkpoin:
![image](https://user-images.githubusercontent.com/31193448/115451620-09dc1b00-a1e3-11eb-855a-ac7ddc3d2bd5.png)

- Achieved checkpoint
![image](https://user-images.githubusercontent.com/31193448/115451694-22e4cc00-a1e3-11eb-8489-9b4695bdb9b2.png)
