### PR TITLE
Feature/daily notification email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'dotenv-rails'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'letter_opener'
+  gem 'launchy'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 4.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,7 @@ DEPENDENCIES
   faker (~> 2.16)
   haml (~> 5.2, >= 5.2.1)
   jbuilder (~> 2.7)
+  launchy
   letter_opener
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -27,7 +27,6 @@ class HabitsController < ApplicationController
 
   def update
     if @habit.update(habit_params)
-      DayCheckJob.perform_now(day_habit: @habit.days.last)
       flash[:success] = 'Habit updated successfully'
       redirect_to @habit
     else

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -27,6 +27,7 @@ class HabitsController < ApplicationController
 
   def update
     if @habit.update(habit_params)
+      DayCheckJob.perform_now(day_habit: @habit.days.last)
       flash[:success] = 'Habit updated successfully'
       redirect_to @habit
     else

--- a/app/jobs/day_check_job.rb
+++ b/app/jobs/day_check_job.rb
@@ -1,0 +1,7 @@
+class DayCheckJob < ApplicationJob
+  queue_as :default
+
+  def perform(day_habit)
+    DayCheckMailer.with(day_habit: day_habit).day_check_email.deliver_now
+  end
+end

--- a/app/jobs/day_check_job.rb
+++ b/app/jobs/day_check_job.rb
@@ -1,7 +1,17 @@
 class DayCheckJob < ApplicationJob
   queue_as :default
 
-  def perform(day_habit)
-    DayCheckMailer.with(day_habit: day_habit).day_check_email.deliver_now
+  def perform(*args)
+    days = get_unchecked_days
+    return if days.empty?
+    days.each do |day|
+      DayCheckMailer.with(day_habit: day).day_check_email.deliver_later!
+    end
+  end
+
+  private
+
+  def get_unchecked_days
+    days = Day.where(status: false, date: Date.today)
   end
 end

--- a/app/jobs/day_check_job.rb
+++ b/app/jobs/day_check_job.rb
@@ -12,6 +12,6 @@ class DayCheckJob < ApplicationJob
   private
 
   def get_unchecked_days
-    days = Day.where(status: false, date: Date.today)
+    Day.where(status: false, date: Date.today)
   end
 end

--- a/app/mailers/day_check_mailer.rb
+++ b/app/mailers/day_check_mailer.rb
@@ -1,0 +1,9 @@
+class DayCheckMailer < ApplicationMailer
+  def day_check_email
+    @day_habit = params[:day_habit][:day_habit]
+    @habit = @day_habit.habit
+    @user = @habit.user
+    @email = @user.email
+    mail(to: @email, subject: "Don't forget to check your habit!")
+  end
+end

--- a/app/mailers/day_check_mailer.rb
+++ b/app/mailers/day_check_mailer.rb
@@ -1,6 +1,8 @@
 class DayCheckMailer < ApplicationMailer
+  default from: "from@example.com"
+  
   def day_check_email
-    @day_habit = params[:day_habit][:day_habit]
+    @day_habit = params[:day_habit]
     @habit = @day_habit.habit
     @user = @habit.user
     @email = @user.email

--- a/app/views/day_check_mailer/day_check_email.html.erb
+++ b/app/views/day_check_mailer/day_check_email.html.erb
@@ -17,6 +17,6 @@
     <br>
     ----------
     </p>
-    <p>Link to your habit: <%= link_to "Habit", "#{Rails.root}/habits/#{@habit.id}" %></p>
+    <p>Link to your habit: <%= link_to "Habit", habit_url(@habit) %></p>
   </body>
 </html>

--- a/app/views/day_check_mailer/day_check_email.html.erb
+++ b/app/views/day_check_mailer/day_check_email.html.erb
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p><%= @user.first_name %>!</p>
+    <p>
+    Hey! it's time to check your habit
+    <br>
+    --------------------------
+    </p>
+    <p>Name: <%= @habit.name %></p>
+    <p>Description: <%= @habit.description %></p>
+    <p>Start date: <%= @habit.start_date.to_s(:long) %></p>
+    <p>End date: <%= @habit.end_date.to_s(:long) %></p>
+    <p>Note: <%= @day_habit.note ? @day_habit.note : "No notes for this day" %></p>
+    <br>
+    ----------
+    </p>
+    <p>Link to your habit: <%= link_to "Habit", "#{Rails.root}/habits/#{@habit.id}" %></p>
+  </body>
+</html>

--- a/app/views/day_check_mailer/day_check_email.text.erb
+++ b/app/views/day_check_mailer/day_check_email.text.erb
@@ -1,0 +1,11 @@
+    <%= @user.first_name %>!
+    ===================
+    Hey! it's time to check your habit
+    --------------------------
+    Name: <%= @habit.name %>
+    Description: <%= @habit.description %>
+    Start date: <%= @habit.start_date.to_s(:long) %>
+    End date: <%= @habit.end_date.to_s(:long) %>
+    Note: <%= @day_habit.note ? @day_habit.note : "No notes for this day" %>
+    ----------
+    Link to your habit: <%= link_to "Habit", "#{Rails.root}/habits/#{@habit.id}" %>

--- a/app/views/day_check_mailer/day_check_email.text.erb
+++ b/app/views/day_check_mailer/day_check_email.text.erb
@@ -8,4 +8,4 @@
     End date: <%= @habit.end_date.to_s(:long) %>
     Note: <%= @day_habit.note ? @day_habit.note : "No notes for this day" %>
     ----------
-    Link to your habit: <%= link_to "Habit", "#{Rails.root}/habits/#{@habit.id}" %>
+    Link to your habit: <%= link_to "Habit", habit_url(@habit) %>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -5,3 +5,7 @@ expired_checkpoints:
 expired_habits_reminder:
   class: "ExpiredHabitsReminderJob"
   cron: "0 12 * * * *" # execute daily at 12:00 pm
+
+day_check_job:
+  class: "DayCheckJob"
+  cron: "50 18 * * * *"

--- a/spec/jobs/day_check_job_job_spec.rb
+++ b/spec/jobs/day_check_job_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DayCheckJobJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/day_check_mailer_spec.rb
+++ b/spec/mailers/day_check_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DayCheckMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/day_check_mailer_preview.rb
+++ b/spec/mailers/previews/day_check_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/day_check_mailer
+class DayCheckMailerPreview < ActionMailer::Preview
+  def day_check_email
+    DayCheckMailer.with(day_habit: Day.last).day_check_email
+  end
+end


### PR DESCRIPTION
## Explain why this change is being made.
Scenario 1 - User receives an email notification
- Given the user create a new habit when the habit is not check before at 7pm then the application should   send an email mentioning that its time to track their process
The email should contain: 
-- The habit name
-- The habit description
-- Note of the date
-- A link to the habit detail page, the the user can redirect to the habit page

Scenario 2 - User doesn’t receive an email notification
-- Given the user create a new habit when the habit is check before at 7pm then the application shouldn’t send an email mentioning that it’s time to track their process


## Explain how this is accomplished.
-- Daily, the app checks what Habits haven't been checked, and at 7:00PM an email is sent to the users to remind them to check the day at his habits


## Screenshots
![image](https://user-images.githubusercontent.com/25086862/115466895-51b86d80-a1f6-11eb-9689-4bd1d788b1c8.png)

![image](https://user-images.githubusercontent.com/25086862/115466948-61d04d00-a1f6-11eb-85db-2df1e39e29e5.png)

![image](https://user-images.githubusercontent.com/25086862/115467122-9fcd7100-a1f6-11eb-8c65-7bba32d32713.png)

