### PR TITLE
Feature/email without tracking habit

### DIFF
--- a/app/jobs/reminder_habit_tracking_job.rb
+++ b/app/jobs/reminder_habit_tracking_job.rb
@@ -1,0 +1,29 @@
+class ReminderHabitTrackingJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    @users = User.all
+
+    @users.each do |user|
+      user.habits.each do |habit|
+        days = habit.days.where('date < ?', Date.today).last(4)
+        HabitTrackingMailer.with(habit: habit).reminder.deliver_later if evaluate_days(days)
+      end
+    end
+  end
+
+  def evaluate_days(days)
+    sum = sum_untracked_days(days)
+    four_days?(sum)
+  end
+
+  def sum_untracked_days(days)
+    sum = 0
+    days.map { |day| sum += 1 unless day.status }
+    sum
+  end
+
+  def four_days?(sum)
+    sum == 4
+  end
+end

--- a/app/mailers/habit_tracking_mailer.rb
+++ b/app/mailers/habit_tracking_mailer.rb
@@ -1,0 +1,6 @@
+class HabitTrackingMailer < ApplicationMailer
+  def reminder
+    @habit = params[:habit]
+    mail(to: @habit.user.email, subject: "Don't forget to track your habit")
+  end
+end

--- a/app/views/habit_tracking_mailer/reminder.html.haml
+++ b/app/views/habit_tracking_mailer/reminder.html.haml
@@ -1,0 +1,3 @@
+%h1 Don't forget to track your habit
+%p You have more than 4 days without tracking your habit.
+= link_to "View my habit", @habit, class: "btn btn-primary"

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,11 +2,8 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <style>
-      /* Email styles need to be inline */
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   </head>
-
   <body>
     <%= yield %>
   </body>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,15 +1,15 @@
 expired_checkpoints:
   class: "ExpiredCheckpointsJob"
   cron: "0 12 * * * *" # execute daily at 12:00 pm
-
 expired_habits_reminder:
   class: "ExpiredHabitsReminderJob"
   cron: "0 12 * * * *" # execute daily at 12:00 pm
-
 day_check_job:
   class: "DayCheckJob"
   cron: "50 18 * * * *"
-
 last_day_habit:
   class: "LastDayHabitJob"
   cron: "* 12 * * * *"
+reminder_tracking_habit:
+  class: "ReminderHabitTrackingJob"
+  cron: "0 19 * * * *" # execute daily at 7:00 pm"

--- a/spec/jobs/reminder_habit_tracking_job_spec.rb
+++ b/spec/jobs/reminder_habit_tracking_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ReminderHabitTrackingJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/habit_tracking_spec.rb
+++ b/spec/mailers/habit_tracking_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe HabitTrackingMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/habit_tracking_preview.rb
+++ b/spec/mailers/previews/habit_tracking_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/habit_tracking
+class HabitTrackingPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
## Explain why this change is being made.
As a registered user with an active habit, I want to receive an email when I have more than four days without tracking a habit so that I can add my progress to the habit.

---

## Explain how this is accomplished.
the register user with an active habit who has not tracked his habit for more than 4 days, should receive an email reminding him to track his habit.

---

## How do you manually test this?
1. As a registered user with a habit saved.
2. Dont track this habit for more than 4 days,
3. You receive an email.

---

## Screenshots
